### PR TITLE
fixed extracting doc with ocamlformat

### DIFF
--- a/bin/apidoc.ml
+++ b/bin/apidoc.ml
@@ -71,7 +71,7 @@ let extract_sections s =
   let _head = Owl.Utils.Stack.to_array sec_head in
   let _body = Owl.Utils.Stack.to_array sec_body in
   Array.iteri (fun i head ->
-    let body = _body.(i + 1) in
+    let body = _body.(i+1) in
     Owl.Utils.Stack.push sections (head, body)
   ) _head;
 
@@ -83,8 +83,8 @@ let parse_one_section regstr s =
   let apidoc = Owl.Utils.Stack.make () in
   let regex = Re.Pcre.regexp ~flags:[`MULTILINE] regstr in
   Re.all regex s |> List.iter (fun mc ->
-    let _fun_typ = Re.Group.get mc 1 in
-    let _fun_doc = Re.Group.get mc 2 in
+    let _fun_typ = Re.Group.get mc 2 in
+    let _fun_doc = Re.Group.get mc 1 in
     let _fun_tup = `Function (_fun_typ, _fun_doc) in
     Owl.Utils.Stack.push apidoc _fun_tup
   );
@@ -93,9 +93,9 @@ let parse_one_section regstr s =
 
 (* given a mli, parse to retrieve api doc and save to a hashtbl *)
 let parse_one_mli fname =
-  let res0 = "^[\s]*(type [\S\s]+?)\(\*\*[\s]*([\S\s]+?)[\s]*\*\)[\s]*?^[\s]*$" in
-  let res1 = "^[\s]*(val .+?)[ \n]*\(\*\*[ \n]*([\S\s]+?)[ \n]*\*\)" in
-  let res2 = "^[\s]*(exception [\S\s]+?)\(\*\*[\s]*([\S\s]+?)[\s]*\*\)[\s]*?^[\s]*$" in
+  let res0 = "^[\s]*\(\*\*[\s]*([\S\s]+?)[\s]*\*\)[\s]*?^[\s]*((type|and) [\S\s]+?)(\n\n|\Z)" in
+  let res1 = "^[\s]*\(\*\*[ \n]*([\S\s]+?)[ \n]*\*\)[\s]*?^[\s]*(val [\S\s]+?)(end|\n\n|\Z)" in
+  let res2 = "^[\s]*\(\*\*[\s]*([\S\s]+?)[\s]*\*\)[\s]*?^[\s]*(exception [\S\s]+?)(\n\n|\Z)" in
 
   let s = get_content fname in
   let sections = extract_sections s in

--- a/bin/module.txt
+++ b/bin/module.txt
@@ -15,8 +15,8 @@ owl/cblas/owl_cblas.mli | owl/cblas/owl_cblas.ml | High-level CBLAS API
 owl/lapacke/owl_lapacke_generated.mli | owl/lapacke/owl_lapacke_generated.ml | Low-level LAPACKE API
 owl/lapacke/owl_lapacke.mli | owl/lapacke/owl_lapacke.ml | High-level LAPACKE API
 base/optimise/owl_numdiff_generic_sig.ml | base/optimise/owl_numdiff_generic.ml | Numdiff.Generic Functor
-base/optimise/owl_algodiff_generic_sig.ml | base/optimise/owl_algodiff_generic.ml | Algodiff.Generic Functor
 base/optimise/owl_optimise_generic_sig.ml | base/optimise/owl_optimise_generic.ml | Optimise.Generic Functor
+base/optimise/algodiff/owl_algodiff_generic_sig.ml  | base/optimise/algodiff/owl_algodiff_generic.ml | Algodiff.Generic Functor
 owl/optimise/owl_regression_generic_sig.ml | owl/optimise/owl_regression_generic.ml | Regression.Generic Functor
 base/neural/owl_neural_neuron_sig.ml | base/neural/owl_neural_neuron.ml | Neural.Neuron Functor
 base/neural/owl_neural_graph_sig.ml | base/neural/owl_neural_graph.ml | Neural.Graph Functor


### PR DESCRIPTION
changed regex such that we extract code from below doc-strings (thing regex is matching) as opposed to extracting from above it

should now be able to work with ocamlformat